### PR TITLE
Fix some compiler warnings

### DIFF
--- a/include/c/c_math.h
+++ b/include/c/c_math.h
@@ -4,7 +4,7 @@
 #include <common.h>
 
 namespace cM {
-static s16 atan2s(f32, f32);
+s16 atan2s(f32, f32);
 void initRnd(s32);
 f32 rnd();
 int rndInt(int max);

--- a/include/nw4r/snd/snd_Util.h
+++ b/include/nw4r/snd/snd_Util.h
@@ -47,7 +47,7 @@ struct DataRef {
 
 template <typename T> struct Table {
     u32 count; // at 0x0
-    T items[]; // at 0x4
+    T items[1]; // at 0x4
 };
 
 template <typename T0, typename T1, typename T2, typename T3>

--- a/src/f/f_base.cpp
+++ b/src/f/f_base.cpp
@@ -120,7 +120,7 @@ int fBase_c::doDelete() {
 /* 802e1680 */
 int fBase_c::createPack() {
     // Returns PACK_RESULT_e
-    return commonPack(&create, &preCreate, &postCreate);
+    return commonPack(&fBase_c::create, &fBase_c::preCreate, &fBase_c::postCreate);
 }
 
 /* 802e1730 */
@@ -168,7 +168,7 @@ void fBase_c::postDelete(MAIN_STATE_e state) {
 /* 802e15d0 */
 int fBase_c::deletePack() {
     // Returns PACK_RESULT_e
-    return commonPack(&doDelete, &preDelete, &postDelete);
+    return commonPack(&fBase_c::doDelete, &fBase_c::preDelete, &fBase_c::postDelete);
 }
 
 /* 802e1910 */
@@ -195,12 +195,12 @@ void fBase_c::postExecute(MAIN_STATE_e state) {
 /* 802e1960 */
 int fBase_c::executePack() {
     // Returns PACK_RESULT_e
-    int result = commonPack(&execute, &preExecute, &postExecute);
+    int result = commonPack(&fBase_c::execute, &fBase_c::preExecute, &fBase_c::postExecute);
 
     // Check force update list (bamboo cut to force a cut type of thing)
     fLiNdBa_c *node = m_forceExecuteList.getFirst();
     while (node != nullptr) {
-        node->p_owner->commonPack(&execute, &preExecute, &postExecute);
+        node->p_owner->commonPack(&fBase_c::execute, &fBase_c::preExecute, &fBase_c::postExecute);
         fLiNdBa_c *tempNode = node->getNext();
         m_forceExecuteList.remove(node);
         node = tempNode;
@@ -233,7 +233,7 @@ void fBase_c::postDraw(MAIN_STATE_e state) {
 /* 802e1ae0 */
 int fBase_c::drawPack() {
     // Returns PACK_RESULT_e
-    return commonPack(&draw, &preDraw, &postDraw);
+    return commonPack(&fBase_c::draw, &fBase_c::preDraw, &fBase_c::postDraw);
 }
 
 /* 802e1b90 */


### PR DESCRIPTION
Not all warnings - some are due to not yet implemented functions - but at least the ones that stem from includes.