### PR TITLE
Fix dAcBomb_c::createHeap() return value

### DIFF
--- a/src/d/a/obj/d_a_obj_bomb.cpp
+++ b/src/d/a/obj/d_a_obj_bomb.cpp
@@ -13,7 +13,9 @@ STATE_DEFINE(dAcBomb_c, Explode);
 STATE_DEFINE(dAcBomb_c, Carry);
 STATE_DEFINE(dAcBomb_c, WindCarry);
 
-bool dAcBomb_c::createHeap() {}
+bool dAcBomb_c::createHeap() {
+    return true;
+}
 
 int dAcBomb_c::create() {
     return SUCCEEDED;


### PR DESCRIPTION
## Summary

The `dAcBomb_c::createHeap()` function signature requires a `bool` return type, but the implementation was empty, resulting in undefined behavior. 

The original binary contains `li r3, 0x1` followed by `blr`, which corresponds to returning `true` (1).

## Changes

- Fixed `createHeap()` to return `true` instead of having an empty body

## Testing

Verified that the compiled assembly now matches the original binary for this function.