### PR TITLE
dSndRng_c::rndInt OK

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -832,7 +832,7 @@ config.libs = [
             Object(Matching, "d/snd/d_snd_rng_link_voice.cpp"),
             Object(NonMatching, "d/snd/d_snd_fi_vocal_mgr.cpp"),
             Object(NonMatching, "d/snd/d_snd_data.cpp"),
-            Object(NonMatching, "d/snd/d_snd_rng.cpp"),
+            Object(Matching, "d/snd/d_snd_rng.cpp"),
             Object(Matching, "d/snd/d_snd_rng_mgr.cpp"),
             Object(Matching, "d/snd/d_snd_rng_id.cpp"),
             Object(Matching, "d/snd/d_snd_rng_id_if.cpp"),

--- a/src/d/snd/d_snd_rng.cpp
+++ b/src/d/snd/d_snd_rng.cpp
@@ -13,23 +13,8 @@ void dSndRng_c::init() {
 }
 
 u32 dSndRng_c::rndInt(s32 max) {
-    // TODO
-    return 0;
-/*
-    s32 temp_r0;
-    s32 temp_r11;
-
-    temp_r11 = this->unkC;
-    this->unkC = (temp_r11 * 0xB2E3D431) + 0x508EBD;
-    temp_r0 = MULTU_HI(temp_r11, 0xB2E3D431) + (this->unk8 * 0xB2E3D431) + (temp_r11 * 0x690379B2) + M2C_CARRY;
-    this->unk8 = temp_r0;
-    return MULTU_HI(temp_r0, arg0) + (0 * arg0);
-=>
-
-    lo_1 = (lo_0 * 0xB2E3D431) + 0x508EBD;
-    hi_1 = MULTU_HI(lo_0, 0xB2E3D431) + (hi_0 * 0xB2E3D431) + (lo_0 * 0x690379B2) + M2C_CARRY;
-    return MULTU_HI(hi_1, arg0) + (0 * arg0);
-*/
+    field_0x08 = field_0x08 * 0x690379B2B2E3D431ULL + 0x508EBD;
+    return (u32)(((u64)(field_0x08 >> 32) * (u64)(u32)max) >> 32);
 }
 
 bool dSndRng_c::rndBool(s32 chance) {


### PR DESCRIPTION
Implements `dSndRng_c::rndInt` as a 64-bit LCG matching the original binary.

`d_snd_rng` goes from 3/4 to 4/4 functions matched (100%).