### PR TITLE
dSndSourceEnemyAnim_c sound overrides OK

### DIFF
--- a/include/d/snd/d_snd_source_enemy.h
+++ b/include/d/snd/d_snd_source_enemy.h
@@ -30,13 +30,15 @@ public:
         return specializeBgHitSoundId(soundId, mPolyAttr0, mPolyAttr1);
     }
 
+protected:
+    void unregisterEnemySource();
+
 private:
     // Probably not a problem for weak function order since getName is emitted
     // earlier through an explicit call
     bool isName(const char *name) const {
         return streq(name, getName());
     }
-    void unregisterEnemySource();
 
     /* 0x15C */ nw4r::ut::Node mMgrEnemyLink;
     /* 0x164 */ UNKWORD field_0x164;

--- a/src/d/snd/d_snd_source_enemy.cpp
+++ b/src/d/snd/d_snd_source_enemy.cpp
@@ -123,12 +123,39 @@ u32 dSndSourceEnemy_c::overrideHoldSoundId(u32 soundId, bool initial) {
 }
 
 u32 dSndSourceEnemyAnim_c::overrideStartSoundId(u32 soundId) {
-    // TODO
+    switch (mSourceType) {
+        case SND_SOURCE_MAGUPPO:
+            if (mSubtype == 1) {
+                switch (soundId) {
+                    case SE_EMagupp_APPEAR:     soundId = SE_EMagupp_APPEAR_SAND; break;
+                    case SE_EMagupp_DISAPPEAR:  soundId = SE_EMagupp_DISAPPEAR_SAND; break;
+                    case SE_EMagupp_WATER0:     soundId = SE_EMagupp_WATER0_SAND; break;
+                    case SE_EMagupp_SWIM:       soundId = SE_EMagupp_SWIM_SAND; break;
+                    case SE_EMagupp_BLOWNUP_LV: soundId = SE_EMagupp_BLOWNUP_LV_SAND; break;
+                }
+            }
+            break;
+        case SND_SOURCE_LIZARUFOS:
+            if (mSubtype == 0 && soundId == SE_ELizaru_FIRE_LV) {
+                soundId = SE_ELizaru_FIRE_LV_MA;
+            }
+            if (soundId == SE_E_DISAPPEAR) {
+                unregisterEnemySource();
+            }
+            break;
+        case SND_SOURCE_BC_Z:
+            if (soundId == SE_E_DISAPPEAR) {
+                unregisterEnemySource();
+            }
+            break;
+    }
     return soundId;
 }
 
 u32 dSndSourceEnemyAnim_c::overrideHoldSoundId(u32 soundId, bool initial) {
-    // TODO
+    if (mSourceType == SND_SOURCE_MAGUPPO && mSubtype == 1 && soundId == SE_EMagupp_BLOWNUP_LV) {
+        soundId = SE_EMagupp_BLOWNUP_LV_SAND;
+    }
     return soundId;
 }
 


### PR DESCRIPTION
Implements `dSndSourceEnemyAnim_c::overrideStartSoundId` and `overrideHoldSoundId`, both previously stubbed.

Also bumps `dSndSourceEnemy_c::unregisterEnemySource()` from `private` to `protected` so the subclass can call it (matches what the original asm does at `bl unregisterEnemySource__17dSndSourceEnemy_cFv`).

`d_snd_source_enemy` goes from 17/22 to 19/22 functions matched (+268 bytes).