### PR TITLE
MSL arith: add labs()

### DIFF
--- a/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/arith.c
+++ b/src/PowerPC_EABI_Support/MSL/MSL_C/MSL_Common/Src/arith.c
@@ -8,6 +8,14 @@ int abs(int n) {
         return (n);
 }
 
+/* 804C91F8-804C9208 .text            labs */
+long labs(long n) {
+    if (n < 0)
+        return (-n);
+    else
+        return (n);
+}
+
 /* 80365078-803650D0 35F9B8 0058+00 0/0 1/1 0/0 .text            div */
 div_t div(int numerator, int denominator) {
     div_t ret;


### PR DESCRIPTION
Adds the missing `labs()` function in MSL's `arith.c`. Same implementation pattern as the existing `abs()`, which compiles to the exact same 4-instruction sequence (`srawi`, `xor`, `subf`, `blr`) as the original binary.

`arith` goes from 2/3 to 3/3 functions matched (108→124 bytes, now 100%).