### PR TITLE
dSnd3DActor_c::getSomeUserParam OK

### DIFF
--- a/src/d/snd/d_snd_3d_actor.cpp
+++ b/src/d/snd/d_snd_3d_actor.cpp
@@ -191,3 +191,11 @@ const char *dSnd3DActor_c::soundIdToSoundLabel(u32 soundId) const {
         return dSndMgr_c::getSoundLabelString(soundId);
     }
 }
+
+u32 dSnd3DActor_c::getSomeUserParam(u32 soundId) const {
+    if (mIsDemoActor) {
+        return dSndPlayerMgr_c::GetInstance()->getDemoArchiveDirectly()->GetSoundUserParam(soundId);
+    } else {
+        return dSndPlayerMgr_c::GetInstance()->getSomeUserParam(soundId);
+    }
+}


### PR DESCRIPTION
Implements `dSnd3DActor_c::getSomeUserParam`, which was declared in the header but not yet implemented.

The function follows the same `mIsDemoActor` branching pattern as `soundIdToSoundLabel` directly above it: if the actor is a demo actor, look up the sound user param through the demo archive (`getDemoArchiveDirectly()` returns `&mDemoSoundArchive` at offset 0x28); otherwise delegate to `dSndPlayerMgr_c::GetInstance()->getSomeUserParam()`.

Byte-exact match confirmed via dtk disasm. +32 bytes / +1 function, no regressions.