### PR TITLE
Match dLytMapCapture_c::isBusyRendering and execute

### DIFF
--- a/src/d/lyt/d_lyt_map_capture.cpp
+++ b/src/d/lyt/d_lyt_map_capture.cpp
@@ -30,3 +30,11 @@ void dLytMapCapture_c::executeState_RenderingWaitStep2() {
     }
 }
 void dLytMapCapture_c::finalizeState_RenderingWaitStep2() {}
+
+bool dLytMapCapture_c::isBusyRendering() const{
+    return mIsBusyRendering;
+}
+
+void dLytMapCapture_c::execute() {
+    mStateMgr.executeState();
+}


### PR DESCRIPTION
First PR!

Matches the following functions in d_lyt_map_capture:
- dLytMapCapture_c::isBusyRendering() const
- dLytMapCapture_c::execute()