### PR TITLE
Match d_snd_bgm_reverb and d_snd_stage_reverb

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -774,7 +774,7 @@ config.libs = [
             Object(Matching, "d/snd/d_snd_3d_manager.cpp"),
             Object(NonMatching, "d/snd/d_snd_state_mgr.cpp"),
             Object(Matching, "d/snd/d_snd_stage_data.cpp"),
-            Object(NonMatching, "d/snd/d_snd_stage_reverb.cpp"),
+            Object(Matching, "d/snd/d_snd_stage_reverb.cpp"),
             Object(NonMatching, "d/snd/d_snd_stage_callbacks.cpp"),
             Object(NonMatching, "d/snd/d_snd_event_callbacks.cpp"),
             Object(NonMatching, "d/snd/d_snd_event_demo_callbacks.cpp"),

--- a/configure.py
+++ b/configure.py
@@ -789,7 +789,7 @@ config.libs = [
             Object(Matching, "d/snd/d_snd_bgm_sound_battle.cpp"),
             Object(Matching, "d/snd/d_snd_bgm_sound_harp_mgr.cpp"),
             Object(Matching, "d/snd/d_snd_bgm_seq_data_mgr.cpp"),
-            Object(NonMatching, "d/snd/d_snd_bgm_reverb.cpp"),
+            Object(Matching, "d/snd/d_snd_bgm_reverb.cpp"),
             Object(Matching, "d/snd/d_snd_bgm_seq_config.cpp"),
             Object(Matching, "d/snd/d_snd_bgm_harp_data.cpp"),
             Object(Matching, "d/snd/d_snd_bgm_mml_parser_base.cpp"),

--- a/src/d/snd/d_snd_bgm_reverb.cpp
+++ b/src/d/snd/d_snd_bgm_reverb.cpp
@@ -1,0 +1,19 @@
+#include "common.h"
+#include "nw4r/snd/snd_FxReverbStdDpl2.h"
+
+extern "C" void fn_8037BD30(nw4r::snd::detail::FxReverbStdParam &param) {
+    param.field_0x00 = 0.1f;
+    param.field_0x04 = 2.0f;
+    param.field_0x08 = 0.2f;
+    param.field_0x0C = 0.7f;
+    param.field_0x10 = 1.0f;
+    param.field_0x14 = 4;
+    param.field_0x18 = 0.15f;
+    param.field_0x1C = 4;
+    param.field_0x20 = 0.3f;
+    param.field_0x24 = 1.0f;
+}
+
+extern "C" void fn_8037BD80(nw4r::snd::detail::FxReverbStdParam &param) {
+    fn_8037BD30(param);
+}

--- a/src/d/snd/d_snd_stage_reverb.cpp
+++ b/src/d/snd/d_snd_stage_reverb.cpp
@@ -1,0 +1,87 @@
+#include "common.h"
+#include "nw4r/snd/snd_FxReverbStdDpl2.h"
+
+extern "C" void fn_80366430(nw4r::snd::detail::FxReverbStdParam &param) {
+    param.field_0x00 = 0.02f;
+    param.field_0x04 = 3.0f;
+    param.field_0x08 = 0.6f;
+    param.field_0x0C = 0.4f;
+    param.field_0x10 = 1.0f;
+    param.field_0x20 = 0.0f;
+    param.field_0x24 = 1.0f;
+    param.field_0x14 = 7;
+    param.field_0x1C = 4;
+    param.field_0x18 = 0.02f;
+}
+
+extern "C" void fn_80366480(nw4r::snd::detail::FxReverbStdParam &param) {
+    param.field_0x00 = 0.1f;
+    param.field_0x04 = 3.0f;
+    param.field_0x08 = 0.6f;
+    param.field_0x0C = 0.4f;
+    param.field_0x10 = 1.0f;
+    param.field_0x20 = 0.0f;
+    param.field_0x24 = 1.0f;
+    param.field_0x14 = 5;
+    param.field_0x1C = 5;
+    param.field_0x18 = 0.1f;
+}
+
+extern "C" void fn_803664D0(nw4r::snd::detail::FxReverbStdParam &param) {
+    param.field_0x00 = 0.1f;
+    param.field_0x04 = 5.0f;
+    param.field_0x08 = 0.6f;
+    param.field_0x0C = 1.0f;
+    param.field_0x10 = 1.0f;
+    param.field_0x20 = 1.0f;
+    param.field_0x24 = 1.0f;
+    param.field_0x14 = 0;
+    param.field_0x1C = 5;
+    param.field_0x18 = 0.1f;
+}
+
+extern "C" void fn_80366520(nw4r::snd::detail::FxReverbStdParam &param) {
+    param.field_0x00 = 0.05f;
+    param.field_0x04 = 0.5f;
+    param.field_0x08 = 0.5f;
+    param.field_0x0C = 0.5f;
+    param.field_0x10 = 1.0f;
+    param.field_0x20 = 0.5f;
+    param.field_0x24 = 1.0f;
+    param.field_0x14 = 1;
+    param.field_0x1C = 2;
+    param.field_0x18 = 0.05f;
+}
+
+extern "C" void fn_80366560(nw4r::snd::detail::FxReverbStdParam &param) {
+    param.field_0x00 = 0.02f;
+    param.field_0x04 = 3.0f;
+    param.field_0x08 = 0.6f;
+    param.field_0x0C = 0.4f;
+    param.field_0x10 = 1.0f;
+    param.field_0x20 = 0.0f;
+    param.field_0x24 = 1.0f;
+    param.field_0x14 = 0;
+    param.field_0x1C = 4;
+    param.field_0x18 = 0.02f;
+}
+
+extern "C" void fn_803665B0(nw4r::snd::detail::FxReverbStdParam &param, int preset) {
+    if (preset == 1) goto case1;
+    if (preset == 2) goto case2;
+    if (preset == 3) goto case3;
+    if (preset == 4) goto case4;
+    fn_80366430(param);
+    return;
+case1:
+    fn_80366480(param);
+    return;
+case2:
+    fn_803664D0(param);
+    return;
+case3:
+    fn_80366520(param);
+    return;
+case4:
+    fn_80366560(param);
+}


### PR DESCRIPTION
Matches `d_snd_bgm_reverb.cpp` and `d_snd_stage_reverb.cpp` (100% code + data).

Both files build a `nw4r::snd::detail::FxReverbStdParam` field by field:

- **`d_snd_bgm_reverb.cpp`** — `fn_8037BD30` initializes the param struct; `fn_8037BD80` tail-calls it.
- **`d_snd_stage_reverb.cpp`** — 5 reverb presets (`fn_80366430`..`fn_80366560`) plus the dispatcher `fn_803665B0` (already forward-declared/used by `d_snd_state_mgr.cpp`).

### Notes
- The original assigns the struct fields in the order `0x00..0x10`, then `0x20`, `0x24`, then `0x14`, `0x1C`, `0x18` — not struct-declaration order. The C++ assignment order mirrors that to match the store sequence.
- The `fn_803665B0` dispatcher uses `goto` labels so the default case is emitted inline before the case-target blocks (a plain `switch` places it last), matching the original branch layout.
